### PR TITLE
feat: remove Sendable

### DIFF
--- a/test/TestArith.flix
+++ b/test/TestArith.flix
@@ -16,7 +16,7 @@
 
 mod TestArith {
 
-    enum Exp with Eq, ToString, Sendable {
+    enum Exp with Eq, ToString {
         case Num(Int32),
         case Add(Exp, Exp),
         case Sub(Exp, Exp),


### PR DESCRIPTION
After https://github.com/flix/flix/pull/9556 there is no Sendable trait or `Channel.unsafeSend`. You can just send anything. This PR fixes that